### PR TITLE
Remove sigkill handle

### DIFF
--- a/src/large-sort.ts
+++ b/src/large-sort.ts
@@ -26,7 +26,7 @@ function deleteFiles(tempFolder: string) {
 }
 
 // Doing a best effort to clean any lingering split files
-process.on('SIGKILL', cleanTempFiles);
+process.on('SIGTERM', cleanTempFiles);
 process.on('beforeExit', cleanTempFiles);
 process.on('exit', cleanTempFiles);
 

--- a/src/large-sort.ts
+++ b/src/large-sort.ts
@@ -26,6 +26,7 @@ function deleteFiles(tempFolder: string) {
 }
 
 // Doing a best effort to clean any lingering split files
+process.on('SIGINT', cleanTempFiles);
 process.on('SIGTERM', cleanTempFiles);
 process.on('beforeExit', cleanTempFiles);
 process.on('exit', cleanTempFiles);


### PR DESCRIPTION
Replace the listener on the SIGKILL IPC signal by a listener on SIGINT and SIGTERM to prevent the following error:
`uv_signal_start EINVAL`

It is not allowed to listen on SIGKILL according to nodeJS documentation:
https://nodejs.org/docs/latest-v18.x/api/process.html#signal-events